### PR TITLE
Corrections for Vagrant 1.6.3 and vagrant-berkshelf 2.0.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+
+# all Unix / CYGWIN shell scripts must be unix
+*.sh text eol=lf
+Vagrantfile text eol=lf
+preseed.cfg text eol=lf

--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Afterwards use the Vagrantfile with the base box to install the rest of the VM.
 
 ```bash
 $ cd vagrant/ubuntu_1310/
-$ vagrant plugin install vagrant-berkshelf
+$ vagrant plugin install vagrant-berkshelf --plugin-version '>= 2.0.1'
 $ bundle
 $ berks
 $ vagrant up
 ```
 
-Tested with packer 0.5.1, vagrant 1.4.3, virtual box 4.3.6 on Mac OSX 10.9.1. Created an Ubuntu 13.10 box.
+Tested with packer 0.6.0, vagrant 1.6.3, virtual box 4.3.12 on Mac OSX 10.9.3. Created an Ubuntu 13.10 box.

--- a/vagrant/ubuntu_1310/Berksfile
+++ b/vagrant/ubuntu_1310/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source "https://api.berkshelf.com"
 
 cookbook 'apt'
 cookbook 'build-essential'

--- a/vagrant/ubuntu_1310/Berksfile.lock
+++ b/vagrant/ubuntu_1310/Berksfile.lock
@@ -1,54 +1,49 @@
-{
-  "sources": {
-    "apt": {
-      "locked_version": "2.3.4"
-    },
-    "build-essential": {
-      "locked_version": "1.3.2"
-    },
-    "git": {
-      "locked_version": "2.9.0"
-    },
-    "dev_box": {
-      "path": "./cookbooks/dev_box"
-    },
-    "ruby_build": {
-      "locked_version": "0.7.2"
-    },
-    "rbenv": {
-      "locked_version": "0.7.3",
-      "git": "git://github.com/fnichol/chef-rbenv.git",
-      "ref": "9afb4e5da2e6212504a12de3bbbd410cd96100f6"
-    },
-    "nodejs": {
-      "locked_version": "1.3.0"
-    },
-    "mysql": {
-      "locked_version": "2.1.0"
-    },
-    "dmg": {
-      "locked_version": "2.1.4"
-    },
-    "windows": {
-      "locked_version": "1.12.8"
-    },
-    "chef_handler": {
-      "locked_version": "1.1.4"
-    },
-    "runit": {
-      "locked_version": "1.5.8"
-    },
-    "yum": {
-      "locked_version": "3.0.6"
-    },
-    "yum-epel": {
-      "locked_version": "0.2.0"
-    },
-    "java": {
-      "locked_version": "1.19.2"
-    },
-    "openssl": {
-      "locked_version": "1.1.0"
-    }
-  }
-}
+DEPENDENCIES
+  apt
+  build-essential
+  dev_box
+    path: cookbooks/dev_box
+  git
+  mysql
+  nodejs
+  rbenv
+    git: git://github.com/fnichol/chef-rbenv.git
+    revision: 0a3018634bafe58ad21c6ee271af015220e444b9
+  ruby_build
+
+GRAPH
+  apt (2.4.0)
+  build-essential (2.0.4)
+  chef_handler (1.1.6)
+  dev_box (0.0.0)
+    apt (>= 0.0.0)
+  dmg (2.2.0)
+  git (4.0.2)
+    build-essential (>= 0.0.0)
+    dmg (>= 0.0.0)
+    runit (>= 1.0.0)
+    windows (>= 0.0.0)
+    yum (~> 3.0)
+    yum-epel (>= 0.0.0)
+  java (1.22.0)
+  mysql (5.3.0)
+    yum-mysql-community (>= 0.0.0)
+  nodejs (1.3.0)
+    apt (>= 0.0.0)
+    build-essential (>= 0.0.0)
+    yum (>= 0.0.0)
+  rbenv (0.7.3)
+    java (> 1.4.0)
+    ruby_build (>= 0.0.0)
+  ruby_build (0.8.0)
+  runit (1.5.10)
+    build-essential (>= 0.0.0)
+    yum (~> 3.0)
+    yum-epel (>= 0.0.0)
+  windows (1.31.0)
+    chef_handler (>= 0.0.0)
+  yum (3.2.0)
+  yum-epel (0.3.6)
+    yum (~> 3.0)
+  yum-mysql-community (0.1.0)
+    yum (>= 3.0.0)

--- a/vagrant/ubuntu_1310/Vagrantfile
+++ b/vagrant/ubuntu_1310/Vagrantfile
@@ -34,6 +34,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--vram", 256]
     vb.customize ["modifyvm", :id, "--accelerate3d", 'on']
     vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+    vb.customize ["setextradata", "global", "GUI/SuppressMessages", "all" ]
   end
 
   # update package cache and upgrade to most recent versions

--- a/vagrant/ubuntu_1310/cookbooks/dev_box/metadata.rb
+++ b/vagrant/ubuntu_1310/cookbooks/dev_box/metadata.rb
@@ -1,1 +1,3 @@
+name 'dev_box'
+
 depends "apt"


### PR DESCRIPTION
Here are my changes to make the Vagrantfile work with Vagrant 1.6.3 and the updated vagrant-berkshelf 2.0.1 plugin.
Tested with Packer 0.6.0, Vagrant 1.6.3, VirtualBox 4.3.12 on Mac OSX 10.9.3. Created an Ubuntu 13.10 box.
My box is still provisioning, but everything looks good so far.

But there is a known issue: The vagrant-berkshelf plugin could not be installed on a Windows host at the moment. Tried this today on my work machine and gave up with already known issues (installing dependency dep-selector-libgecode or something like that). Mac and Linux hosts work fine.
